### PR TITLE
Disable UsePrivilegeSeparation for OpenSSH server

### DIFF
--- a/install
+++ b/install
@@ -241,6 +241,9 @@ echo "==> Disabling PasswordAuthentication"
 sed -ri s/^#?PasswordAuthentication\ no/PasswordAuthentication\ no/ -i $INSTALL_DIR/etc/ssh/sshd_config
 sed -ri s/^#?PasswordAuthentication\ yes/PasswordAuthentication\ no/ -i $INSTALL_DIR/etc/ssh/sshd_config
 
+echo "==> Disable UsePrivilegeSeparation"
+sed -ri s/^#?UsePrivilegeSeparation\ sandbox/UsePrivilegeSeparation\ no/ -i $INSTALL_DIR/etc/ssh/sshd_config
+
 echo "==> Creating /etc/motd"
 cat << MOTD > $INSTALL_DIR/etc/motd
    __        .                   .


### PR DESCRIPTION
Newer debian version uses a new version of OpenSSH server which provide sandboxes for priviledge separation by default. However this is not supported by lx-branded zones, so to have working OpenSSH server it's required to disable `UsePrivilegeSeparation` in `sshd_config`.