### PR TITLE
Fix build failure; a variety of cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: bash
-addons:
-  apt:
-    sources:
-    - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-    - shellcheck
+sudo: required
+dist: trusty
+before_install:
+  - sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+  - sudo apt-get update -q
+  - sudo apt-get install shellcheck -y
 script: shellcheck -e SC2086 -s bash create-lx-image create-manifest install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Debian lx-brand Image Builder
 
-[![Build Status](https://travis-ci.org/joyent/debian-lx-brand-image-builder.svg?branch=master)](https://travis-ci.org/joyent/debian-lx-brand-image-builder) (shecllcheck)
+[![Build Status](https://travis-ci.org/joyent/debian-lx-brand-image-builder.svg?branch=master)](https://travis-ci.org/joyent/debian-lx-brand-image-builder) (shellcheck)
 
 This is a collection of scripts used for creating an lx-brand Debian image.
 

--- a/create-lx-image
+++ b/create-lx-image
@@ -52,6 +52,20 @@ do
 			;;
 		t)
 			TARBALL=${OPTARG}
+
+			[ ! -e "$TARBALL" ] && echo "==> ERROR: ${TARBALL}: file or directory not found" && exit 1
+			[ ! -f "$TARBALL" ] && echo "==> ERROR: $TARBALL must be a file" && exit 1
+			[ ! -r "$TARBALL" ] && echo "==> ERROR: $TARBALL is not readable" && exit 1
+			[ "${TARBALL:0:1}" != "/" ] && echo "==> ERROR: the pathname '$TARBALL' specified to '-t' must be absolute" && exit 1
+
+			filetype=$(LC_ALL=C file -b "$TARBALL" 2> /dev/null)
+			case "$filetype" in
+				gzip*)       gtaropts="-xzf" ;;
+				bzip2*)      gtaropts="-xjf" ;;
+				compressed*) gtaropts="-xZf" ;;
+				USTAR*)      gtaropts="-xf"  ;;
+				*) echo "==> ERROR: $TARBALL must be a gzip, bzip2, .Z, or uncompressed tar archive." && exit 1 ;;
+			esac
 			;;
 		k)
 			KERNEL=${OPTARG}
@@ -80,44 +94,7 @@ fi
 
 [ -z "$DOCS" ] && DOCS="https://docs.joyent.com/images/container-native-linux"
 
-if [[ ! -a "$TARBALL" ]]; then
-	printf '==> ERROR: %s: file or directory not found\n' "$TARBALL"
-	exit 1
-fi
-
-if [[ "$(echo $TARBALL | cut -c 1)" != "/" ]]; then
-	printf '==> Pathname '%s' specified to -t must be absolute\n' "$TARBALL"
-	exit 1
-fi
-
-if [[ ! -r "$TARBALL" ]]; then
-	printf '==> Cannot read file '%s'\n' "$TARBALL"
-	exit 1
-fi
-
-if [[ ! -f "$TARBALL" ]]; then
-	echo "==> ERROR: must be a gzip, bzip2, .Z or uncompressed tar archive"
-	exit 1
-fi
-
 IUUID=${IMAGE_NAME}-$BUILD_DATE
-
-filetype=$({ LC_ALL=C file $TARBALL | awk '{print $2}' ; } 2>/dev/null)
-
-if [[ "$filetype" = "gzip" ]]; then
-	gtaropts="-xz"
-elif [[ "$filetype" = "bzip2" ]]; then
-	gtaropts="-xj"
-elif [[ "$filetype" = "compressed" ]]; then
-	gtaropts="-xZ"
-elif [[ "$filetype" = "USTAR" ]]; then
-	gtaropts="-x"
-else
-	printf "==> ERROR: must be a gzip, bzip2, .Z or uncompressed tar archive"
-	exit 1
-fi
-
-gtaropts="${gtaropts}f"
 
 zpath="/zones/$IUUID"
 zroot="/zones/$IUUID/root"

--- a/create-lx-image
+++ b/create-lx-image
@@ -43,12 +43,12 @@ OPTIONS:
 EOF
 }
 
-while getopts "ht:k:m:i:d:u:" OPTION
+while getopts "ht:k:m:i:d:u:?" OPTION
 do
 	case $OPTION in
-		h)
+		h|\?)
 			usage
-			exit 1
+			exit
 			;;
 		t)
 			TARBALL=${OPTARG}
@@ -67,10 +67,6 @@ do
 			;;
 		u)
 			DOCS=${OPTARG}
-			;;
-		?)
-			usage
-			exit
 			;;
 	esac
 done

--- a/create-lx-image
+++ b/create-lx-image
@@ -71,11 +71,14 @@ do
 	esac
 done
 
-if [[ -z $TARBALL ]]; then
-	echo "==> ERROR: the install archive is required"
+if [[ -z "$TARBALL" || -z "$KERNEL" || -z "$MIN_PLATFORM" || \
+      -z "$IMAGE_NAME" || -z "$DESC" ]] ; then
+	printf 'FATAL: -t, -k, -m, -i, and -d options are all required.\n'
 	usage
 	exit 1
 fi
+
+[ -z "$DOCS" ] && DOCS="https://docs.joyent.com/images/container-native-linux"
 
 if [[ ! -a "$TARBALL" ]]; then
 	printf '==> ERROR: %s: file or directory not found\n' "$TARBALL"
@@ -95,30 +98,6 @@ fi
 if [[ ! -f "$TARBALL" ]]; then
 	echo "==> ERROR: must be a gzip, bzip2, .Z or uncompressed tar archive"
 	exit 1
-fi
-
-if [[ -z ${KERNEL} ]]; then
-	echo "Error: missing kernel version (-k) value"
-	exit 1
-fi
-
-if [[ -z ${MIN_PLATFORM} ]]; then
-	echo "Error: missing minimum platform (-m) value"
-	exit 1
-fi
-
-if [[ -z ${IMAGE_NAME} ]]; then
-	echo "Error: missing image name (-i) value"
-	exit 1
-fi
-
-if [[ -z ${DESC} ]]; then
-	echo "Error: missing image description (-d) value"
-	exit 1
-fi
-
-if [[ -z ${DOCS} ]]; then
-	DOCS="https://docs.joyent.com/images/container-native-linux"
 fi
 
 IUUID=${IMAGE_NAME}-$BUILD_DATE

--- a/create-lx-image
+++ b/create-lx-image
@@ -26,7 +26,7 @@ cat <<EOF
 Create an lx brand Debian image from a given tar file
 
 Usage:
-  $0 -t <TARBALL> -k <KERNEL> -m <MIN_PLATFORM> -i <IMAGE_NAME> -d <DESC> -u <DOCS>
+  $0 -t <TARBALL> -k <KERNEL> -m <MIN_PLATFORM> -i <IMAGE_NAME> -d <DESC> [-u <DOCS>]
 
 Example:
   $0 -t /var/tmp/lx-debian-7-20150408.tar.gz -k 3.13.0 -m 20150316T201553Z -i lx-debian-7 -d "Debian 7 64-bit lx-brand image." -u https://docs.joyent.com/images/container-native-linux
@@ -37,7 +37,7 @@ OPTIONS:
   -m The minimum platform required for the image
   -i The name of the image as it would appear in the manifest
   -d The description of the image as it would appear in the manifest
-  -u The homepage link of the image as it would appear in the manifest
+  -u The homepage link of the image as it would appear in the manifest [optional]
   -h Show this message
 
 EOF

--- a/create-lx-image
+++ b/create-lx-image
@@ -82,17 +82,17 @@ if [[ -z $TARBALL ]]; then
 fi
 
 if [[ ! -a "$TARBALL" ]]; then
-	printf "==> ERROR: %s: file or directory not found\n" $TARBALL
+	printf '==> ERROR: %s: file or directory not found\n' "$TARBALL"
 	exit 1
 fi
 
 if [[ "$(echo $TARBALL | cut -c 1)" != "/" ]]; then
-	printf "==> Pathname '%s' specified to -t must be absolute\n" $TARBALL
+	printf '==> Pathname '%s' specified to -t must be absolute\n' "$TARBALL"
 	exit 1
 fi
 
 if [[ ! -r "$TARBALL" ]]; then
-	printf "==> Cannot read file '%s'\n" $TARBALL
+	printf '==> Cannot read file '%s'\n' "$TARBALL"
 	exit 1
 fi
 
@@ -164,8 +164,7 @@ create_dataset() {
 
 install_tar() {
 	echo "==> Installing the tar archive, this will take a few minutes..."
-	( cd "$zroot" && gtar --strip-components=2 "$gtaropts" "$TARBALL" )
-	if [[ "$?" -ne "0" ]] ; then
+	if [[ ! $(cd "$zroot" && gtar --strip-components=2 "$gtaropts" "$TARBALL") ]] ; then
 		echo "==> Error: extraction from tar archive failed."
 		zfs destroy -r zones/$IUUID
 	fi

--- a/create-manifest
+++ b/create-manifest
@@ -47,7 +47,6 @@ Example:
     $0 -f debian-7-20150319.zfs.gz -k 3.4.105 -m 20150316T201553Z -n lx-debian-7 -v 20150319
 
 USAGE
-	exit 1
 }
 
 while getopts d:f:k:m:n:o:v:h:? OPTION
@@ -79,6 +78,7 @@ do
 		;;
 	\?)
 		usage
+		exit
 		;;
 	esac
 done
@@ -86,6 +86,7 @@ done
 if [[ -z ${filename} || -z ${kernel} || -z ${min_platform} || -z ${name} || -z ${version} ]]; then
 	echo "FATAL: All of -f, -k, -m, -n and -v are required."
 	usage
+	exit 1
 fi
 
 if [[ -z ${description} ]]; then
@@ -103,6 +104,7 @@ fi
 if [[ ! -f ${filename} ]]; then
 	echo "FATAL: ${filename} does not exist."
 	usage
+	exit 1
 fi
 
 shasum=$($SUM -x sha1 ${filename} | cut -d' ' -f1)

--- a/install
+++ b/install
@@ -48,10 +48,10 @@ NAME=
 DESC=
 DOCS=
 
-while getopts "hr:d:m:i:p:D:u:" OPTION
+while getopts "hr:d:m:i:p:D:u:?" OPTION
 do
 	case $OPTION in
-		h)
+		h|\?)
 			usage
 			exit
 			;;
@@ -75,10 +75,6 @@ do
 			;;
 		u)
 			DOCS=${OPTARG}
-			;;
-		\?)
-			usage
-			exit
 			;;
 	esac
 done

--- a/install
+++ b/install
@@ -22,7 +22,7 @@ cat <<EOF
 Install and modify Debian in a given directory in a given directory using a given mirror
 
 Usage:
-  $0 -r <RELEASE> -d <INSTALL_DIR> -m <MIRROR> -i <IMAGE_NAME> -p <NAME> -D <DESC> -u <DOCS>
+  $0 -r <RELEASE> -d <INSTALL_DIR> -m <MIRROR> -i <IMAGE_NAME> -p <NAME> -D <DESC> [-u <DOCS>]
 
 Example:
   $0 -r wheezy -d /data/chroot -m http://httpredir.debian.org/debian/ -i lx-debian-7 -p "Debian 7 LX Brand" -D "Debian 7 64-bit lx-brand image." -u https://docs.joyent.com/images/container-native-linux

--- a/install
+++ b/install
@@ -79,38 +79,14 @@ do
 	esac
 done
 
-if [[ $# -eq 0 ]]; then
+if [[ -z "$RELEASE" || "$INSTALL_DIR" || "$MIRROR" || "$IMAGE_NAME" || "$NAME" ]]; then
+	printf 'FATAL: -r, -d, -m, -i, and -p are all required.\n'
 	usage
-	exit 1
-fi
-
-if [[ -z ${RELEASE} ]]; then
-	echo "Error: missing release (-r) value"
 	exit 1
 fi
 
 if [[ ! -e ${INSTALL_DIR} ]] ; then
 	echo "Directory $INSTALL_DIR not found"
-	exit 1
-fi
-
-if [[ -z ${INSTALL_DIR} ]]; then
-	echo "Error: missing install directory (-d) value"
-	exit 1
-fi
-
-if [[ -z ${MIRROR} ]]; then
-	echo "Error: missing mirror (-m) value"
-	exit 1
-fi
-
-if [[ -z ${IMAGE_NAME} ]]; then
-	echo "Error: missing image name (-i) value"
-	exit 1
-fi
-
-if [[ -z ${NAME} ]]; then
-	echo "Error: missing proper name (-p) value"
 	exit 1
 fi
 


### PR DESCRIPTION
This is just a variety of cleanup and unifying of some of the checks across the scripts, since each script did things a bit differently.

There's a lot of small errors left in these scripts --- some dangerous (unquoted `rm`, etc). But I didn't want to send a big stack of changes if they weren't wanted.

These patches are pretty independent, so feel free to cherry-pick as you see fit. If you're interested in more cleanup, let me know and I'll be happy to spend more time on it.

---Alex